### PR TITLE
Python tests with history api + fix cleos get account #1035,#1041

### DIFF
--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -167,6 +167,8 @@ class Cluster(object):
             nodeosArgs += " --plugin eosio::mongo_db_plugin --mongodb-uri %s" % self.mongoUri
             if delMongoData:
                 nodeosArgs += " --delete-all-blocks --mongodb-wipe"
+        else:
+            nodeosArgs += " --plugin eosio::history_plugin --plugin eosio::history_api_plugin --filter-on \"*\""
         if extraNodeosArgs is not None:
             assert(isinstance(extraNodeosArgs, str))
             nodeosArgs += extraNodeosArgs

--- a/tests/launcher_test.py
+++ b/tests/launcher_test.py
@@ -185,9 +185,9 @@ try:
         errorExit("Transfer verification failed. Excepted %s, actual: %s" % (expectedAmount, actualAmount))
 
     Print("Validate last action for account %s" % (testeraAccount.name))
-    action=node.getActions(testeraAccount, -1, -1, exitOnError=True)
+    actions=node.getActions(testeraAccount, -1, -1, exitOnError=True)
     try:
-        assert(action["act"]["name"] == "transfer")
+        assert(actions["actions"][0]["action_trace"]["act"]["name"] == "transfer")
     except (AssertionError, TypeError, KeyError) as _:
         Print("Action validation failed. Actions: %s" % (actions))
         raise
@@ -200,10 +200,10 @@ try:
     amountVal=None
     key=""
     try:
-        key="[actions][0][name]"
-        typeVal=  transaction["actions"][0]["name"]
-        key="[actions][0][data][quantity]"
-        amountVal=transaction["actions"][0]["data"]["quantity"]
+        key="[traces][0][act][name]"
+        typeVal=  transaction["traces"][0]["act"]["name"]
+        key="[traces][0][act][data][quantity]"
+        amountVal=transaction["traces"][0]["act"]["data"]["quantity"]
         amountVal=int(decimal.Decimal(amountVal.split()[0])*10000)
     except (TypeError, KeyError) as e:
         Print("transaction%s not found. Transaction: %s" % (key, transaction))

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -275,10 +275,7 @@ try:
     Print("Validate last action for account %s" % (testeraAccount.name))
     actions=node.getActions(testeraAccount, -1, -1, exitOnError=True)
     try:
-        if not enableMongo:
-            assert(actions["actions"][0]["action_trace"]["act"]["name"] == "transfer")
-        else:
-            assert(actions["act"]["name"] == "transfer")
+        assert(actions["actions"][0]["action_trace"]["act"]["name"] == "transfer")
     except (AssertionError, TypeError, KeyError) as _:
         Print("Action validation failed. Actions: %s" % (actions))
         raise
@@ -291,18 +288,11 @@ try:
     amountVal=None
     key=""
     try:
-        if not enableMongo:
-            key="[traces][0][act][name]"
-            typeVal=  transaction["traces"][0]["act"]["name"]
-            key="[traces][0][act][data][quantity]"
-            amountVal=transaction["traces"][0]["act"]["data"]["quantity"]
-            amountVal=int(decimal.Decimal(amountVal.split()[0])*10000)
-        else:
-            key="[actions][0][name]"
-            typeVal=  transaction["actions"][0]["name"]
-            key="[actions][0][data][quantity]"
-            amountVal=transaction["actions"][0]["data"]["quantity"]
-            amountVal=int(decimal.Decimal(amountVal.split()[0])*10000)
+        key="[traces][0][act][name]"
+        typeVal=  transaction["traces"][0]["act"]["name"]
+        key="[traces][0][act][data][quantity]"
+        amountVal=transaction["traces"][0]["act"]["data"]["quantity"]
+        amountVal=int(decimal.Decimal(amountVal.split()[0])*10000)
     except (TypeError, KeyError) as e:
         Print("transaction%s not found. Transaction: %s" % (key, transaction))
         raise


### PR DESCRIPTION
+ `get_account` api method now returns account info even if there is no `cyber.token` installed
+ fix nodeos_run_test.py, launcher_test.py, nodeos_voting_test.py, nodeos_forked_chain_test.py to work with history_api
    + unify result of `getTransaction` and `getTransactionMdb` (only parts used in tests)
    + unify result of `getActions` and `getActionsMdb` (only parts used in tests)
    + update `getBlockProducerByNum` to support both mongo and history_api
    + update `waitActiveSchedule` to work with history_api (sync without schedule slot info using schedule version)

Resolve #1035, #1041
