### PR TITLE
Set initial schedule from Golos-state #1054 #1055

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -556,10 +556,10 @@ struct controller_impl {
    }
 
 
-    void read_genesis() {
+    void read_genesis(block_state_ptr &block) {
         if (conf.read_genesis) {
             cyberway::genesis::genesis_import reader(conf.genesis_file, self);
-            reader.import();
+            reader.import(block);
         }
     }
 
@@ -582,12 +582,13 @@ struct controller_impl {
 
       head = std::make_shared<block_state>( genheader );
       head->block = std::make_shared<signed_block>(genheader.header);
-      fork_db.set( head );
       set_revision(head->block_num);
 
       bool need_native_accounts = !conf.read_genesis;
       initialize_database(need_native_accounts);
-      read_genesis();
+      read_genesis( head );
+
+      fork_db.set( head );
    }
 
    void initialize_caches() {

--- a/libraries/chain/genesis/genesis_import.cpp
+++ b/libraries/chain/genesis/genesis_import.cpp
@@ -82,10 +82,12 @@ struct genesis_import::impl final {
 
         genesis_ext_header ext_header;
         fc::raw::unpack(in, ext_header);
-        producer_schedule_type schedule = {0, ext_header.producers};
-        block->active_schedule       = schedule;
-        block->pending_schedule      = schedule;
-        block->pending_schedule_hash = fc::sha256::hash(schedule);
+        if (ext_header.producers.size() ) {
+            producer_schedule_type schedule = {0, ext_header.producers};
+            block->active_schedule       = schedule;
+            block->pending_schedule      = schedule;
+            block->pending_schedule_hash = fc::sha256::hash(schedule);
+        }
 
         while (in) {
             table_header t;

--- a/libraries/chain/include/cyberway/genesis/genesis_container.hpp
+++ b/libraries/chain/include/cyberway/genesis/genesis_container.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <eosio/chain/types.hpp>
+#include <eosio/chain/producer_schedule.hpp>
 #include <cyberway/chaindb/controller.hpp>
 #include <fc/reflect/reflect.hpp>
 
@@ -11,7 +12,7 @@ using namespace chaindb;
 
 struct genesis_header {
     char magic[12] = "CyberwayGen";
-    uint32_t version = 1;
+    uint32_t version = 2;
 
     uint32_t tables_count;
 
@@ -19,6 +20,10 @@ struct genesis_header {
         genesis_header oth;
         return string(magic) == oth.magic && version == oth.version;
     }
+};
+
+struct genesis_ext_header {
+    std::vector<producer_key> producers;
 };
 
 struct table_header {
@@ -70,6 +75,7 @@ struct table_row final: sys_table_row {
 
 }} // cyberway::genesis
 
+FC_REFLECT(cyberway::genesis::genesis_ext_header, (producers))
 FC_REFLECT(cyberway::genesis::table_header, (code)(name)(abi_type)(count))
 FC_REFLECT(cyberway::genesis::sys_table_row, (ram_payer)(data))
 FC_REFLECT_DERIVED(cyberway::genesis::table_row, (cyberway::genesis::sys_table_row), (pk)(scope))

--- a/libraries/chain/include/cyberway/genesis/genesis_import.hpp
+++ b/libraries/chain/include/cyberway/genesis/genesis_import.hpp
@@ -15,7 +15,7 @@ public:
     genesis_import(const bfs::path& genesis_file, controller& ctrl);
     ~genesis_import();
 
-    void import();
+    void import(block_state_ptr &block);
 
 private:
     struct impl;

--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -438,28 +438,10 @@ struct genesis_create::genesis_create_impl final {
 
         // first prepare staking balances and sort agents by level. keys and proxy info required to do this
         fc::flat_map<acc_idx,public_key_type> keys;         // agent:key
-        auto hf = _info.params.require_hardfork;
+        std::vector<producer_key> initial_producers = get_producers();
         for (const auto& w: _visitor.witnesses) {
-            auto key = pubkey_from_golos(w.signing_key);
-            if (hf && key != public_key_type()) {
-                // the following cases exist:
-                //  1. running version == required
-                //      a) vote version == required if witness updated node and signed block before HF
-                //          i) vote time == required = ok
-                //          ii) vote time != required = wrong hf, reset
-                //      b) vote version == prev, if witness updated node and signed block after HF, reset
-                //          (almost impossible in final genesis, can affect reserve witness/miner from last schedule)
-                //  2. running version != required = wrong hf or didn't sign a block after node update, reset
-                if (
-                    w.running_version != hf->version
-#ifndef ONLY_CHECK_WITNESS_RUNNING_HF_VERSION
-                    || w.hardfork_version_vote != hf->version || w.hardfork_time_vote != hf->time
-#endif
-                ) {
-                    key = {};
-                }
-            }
-            keys[w.owner.id.value] = key;
+            auto producer = std::find_if(initial_producers.begin(), initial_producers.end(), [&](const auto &prod) {return prod.producer_name == name_by_acc(w.owner);});
+            keys[w.owner.id.value] = (producer == initial_producers.end()) ? public_key_type{} : producer->block_signing_key;
         }
         fc::flat_map<acc_idx,acc_idx> proxies;              // grantor:agent
         const auto& empty_acc = std::distance(_accs_map.begin(), std::find(_accs_map.begin(), _accs_map.end(), string("")));
@@ -1309,8 +1291,10 @@ struct genesis_create::genesis_create_impl final {
     };
 
     std::vector<producer_key> get_producers() {
-        EOS_ASSERT(_info.params.initial_prod_count > 0, genesis_exception,
-                ("initial_prod_count can't be zero"));
+        if (_info.params.initial_prod_count == 0) {
+            return {};
+        }
+
         EOS_ASSERT(_info.params.initial_prod_count <= _visitor.witnesses.size(),
                 genesis_exception, "initial_prod_count (${count}) too large. State has only ${witnesses} witnesses", 
                 ("count", _info.params.initial_prod_count)("witnesses", _visitor.witnesses.size()));

--- a/programs/create-genesis/genesis_info.hpp
+++ b/programs/create-genesis/genesis_info.hpp
@@ -200,10 +200,6 @@ struct genesis_info {
         int64_t depriving_window;
         int64_t min_own_staked_for_election = 0;
     };
-    struct hardfork_info {
-        uint32_t version;       // High byte is major version, next one is hardfork version, low 16bits are revision
-        time_point_sec time;
-    };
     struct funds_share {
         account_name name;
         // value multiplied to base CYBER supply. use num/denom to avoid floating point
@@ -215,7 +211,6 @@ struct genesis_info {
         uint8_t initial_prod_count = 0;
         stake_params stake;
         posting_rules posting_rules;
-        fc::optional<hardfork_info> require_hardfork;
         std::vector<funds_share> funds;
     } params;
 
@@ -263,9 +258,8 @@ FC_REFLECT(cyberway::genesis::genesis_info::golos_config,
     (domain)(names)(recovery)(max_supply)(sys_max_supply)(start_trx))
 FC_REFLECT(cyberway::genesis::genesis_info::stake_params,
     (enabled)(max_proxies)(depriving_window)(min_own_staked_for_election))
-FC_REFLECT(cyberway::genesis::genesis_info::hardfork_info, (version)(time))
 FC_REFLECT(cyberway::genesis::genesis_info::funds_share, (name)(numerator)(denominator))
-FC_REFLECT(cyberway::genesis::genesis_info::parameters, (initial_prod_count)(stake)(posting_rules)(require_hardfork)(funds))
+FC_REFLECT(cyberway::genesis::genesis_info::parameters, (initial_prod_count)(stake)(posting_rules)(funds))
 FC_REFLECT(cyberway::genesis::genesis_info::ee_parameters::ee_history_days, (transfers)(withdraws)(rewards))
 FC_REFLECT(cyberway::genesis::genesis_info::ee_parameters, (history_days))
 FC_REFLECT(cyberway::genesis::genesis_info, (state_file)(genesis_json)(accounts)(auth_links)(transit_account_authorities)(delegateuse)(tables)(golos)(params)(ee_params))

--- a/programs/create-genesis/genesis_info.hpp
+++ b/programs/create-genesis/genesis_info.hpp
@@ -212,6 +212,7 @@ struct genesis_info {
     };
 
     struct parameters {
+        uint8_t initial_prod_count = 0;
         stake_params stake;
         posting_rules posting_rules;
         fc::optional<hardfork_info> require_hardfork;
@@ -264,7 +265,7 @@ FC_REFLECT(cyberway::genesis::genesis_info::stake_params,
     (enabled)(max_proxies)(depriving_window)(min_own_staked_for_election))
 FC_REFLECT(cyberway::genesis::genesis_info::hardfork_info, (version)(time))
 FC_REFLECT(cyberway::genesis::genesis_info::funds_share, (name)(numerator)(denominator))
-FC_REFLECT(cyberway::genesis::genesis_info::parameters, (stake)(posting_rules)(require_hardfork)(funds))
+FC_REFLECT(cyberway::genesis::genesis_info::parameters, (initial_prod_count)(stake)(posting_rules)(require_hardfork)(funds))
 FC_REFLECT(cyberway::genesis::genesis_info::ee_parameters::ee_history_days, (transfers)(withdraws)(rewards))
 FC_REFLECT(cyberway::genesis::genesis_info::ee_parameters, (history_days))
 FC_REFLECT(cyberway::genesis::genesis_info, (state_file)(genesis_json)(accounts)(auth_links)(transit_account_authorities)(delegateuse)(tables)(golos)(params)(ee_params))

--- a/programs/create-genesis/serializer.hpp
+++ b/programs/create-genesis/serializer.hpp
@@ -57,12 +57,14 @@ private:
     bytes _buffer;
 
 public:
-    void start(const bfs::path& out_file, int n_sections) {
+    void start(const bfs::path& out_file, int n_sections, const genesis_ext_header &ext_hdr) {
         out.exceptions(std::ofstream::failbit | std::ofstream::badbit);
         out.open(out_file, std::ios_base::binary);
         genesis_header hdr;
         hdr.tables_count = n_sections;
         out.write((char*)(&hdr), sizeof(hdr));
+        fc::raw::pack(out, ext_hdr);
+
         _section_count = n_sections;
         _buffer.resize(1024*1024);
     }


### PR DESCRIPTION
Resolve #1054 and resolve #1055 

Adds extended header with initial producers schedule into genesis-data (also increase version to 2)
Set initial producers schedule from extended header when initialize chain.
Selects first witnesses who approved transit (by parameter `params.initial_prod_count`)
Remove `require_hardfork` field from genesis-info.json.
Start with `cyber` producer if genesis-data doesn't contains producer's schedule.