### PR TITLE
Fix replaying with enabled history plugin #1048

### DIFF
--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -161,7 +161,6 @@ namespace cyberway { namespace chaindb {
         ~chaindb_controller_impl() = default;
 
         void restore_db() {
-            history_abi_info_.abi().verify_tables_structure(driver_);
             system_abi_info_.init_abi();
             undo_.restore();
         }
@@ -171,6 +170,12 @@ namespace cyberway { namespace chaindb {
             undo_.clear(); // remove all undo states
             journal_.clear(); // remove all pending changes
             driver_.drop_db(); // drop database
+        }
+
+        void initialize_db() {
+            drop_db(); // force to drop old database
+            system_abi_info_.abi().verify_tables_structure(driver_);
+            history_abi_info_.abi().verify_tables_structure(driver_);
         }
 
         const cursor_info& current(const cursor_info& cursor) const {
@@ -763,6 +768,10 @@ namespace cyberway { namespace chaindb {
 
     void chaindb_controller::drop_db() const {
         impl_->drop_db();
+    }
+
+    void chaindb_controller::initialize_db() const {
+        impl_->initialize_db();
     }
 
     void chaindb_controller::push_cache() const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -568,7 +568,7 @@ struct controller_impl {
     */
    void initialize_fork_db() {
       wlog( " Initializing new blockchain with genesis state                  " );
-      chaindb.drop_db();
+      chaindb.initialize_db();
       producer_schedule_type initial_schedule{ 0, {{config::system_account_name, conf.genesis.initial_key}} };
 
       block_header_state genheader;

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -123,6 +123,7 @@ namespace cyberway { namespace chaindb {
         const undo_stack& get_undo_stack() const;
 
         void restore_db() const;
+        void initialize_db() const;
         void drop_db() const;
         void push_cache() const;
 

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -682,6 +682,7 @@ class Cluster(object):
         assert(isinstance(initialBalances, dict))
         assert(isinstance(transferAmount, int))
 
+        time.sleep(3)
         for node in self.nodes:
             if node.killed:
                 continue


### PR DESCRIPTION
Resolve #1048:
- chain-plugin calls `drop_db()` on replaying and removing blocklog
- chain-controller calls `chaindb_controller::initialize_db()` on self-initialize
- add sleep to wait sync between nodes in python tests.
