### PR TITLE
Initialize emission #1064

### DIFF
--- a/programs/create-genesis/serializer.hpp
+++ b/programs/create-genesis/serializer.hpp
@@ -39,7 +39,7 @@ enum class stored_contract_tables: int {
     stake_agents,   stake_cands,
     stake_grants,   stake_provisions,
     stake_stats,    stake_params,
-    memo_key,       start_transaction,
+    memo_key,       emit_transaction, emit_state,
 
     _max                // to simplify setting tables_count of genesis container
 };


### PR DESCRIPTION
Resolve #1064
- change action from `gls.emit:start` to `gls.emit:emit`
- create `gls.emit:state` record (can't create in genesis-info because need Golos last block time)

Note: remove trx_id from `gls.emit:state` record (made in cyberway/golos.contracts#852)