### PR TITLE
Using Golos usernames in created accounts #1067

### DIFF
--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -200,7 +200,7 @@ struct genesis_create::genesis_create_impl final {
     void parse_and_store_permissions(account_name n, const std::vector<genesis_info::permission>& permissions, uint64_t& id, std::map<permission_name,perm_id_t>& parents, const public_key_type& initial_key) {
         const uint64_t max_custom_parent_id = 100;            // this should be enough to cover build-in permissions
         for (const auto& p: permissions) {
-            const auto& auth = p.make_authority(initial_key, n);
+            const auto& auth = p.make_authority(initial_key, n, [&](const std::string& username){return name_by_username(username);});
             auto parent = p.get_parent();
             bool root = parent == eosio::chain::name();
             bool custom_parent = !root && parent.value < max_custom_parent_id;

--- a/programs/create-genesis/genesis_info.hpp
+++ b/programs/create-genesis/genesis_info.hpp
@@ -60,13 +60,13 @@ struct genesis_info {
             return std::make_pair(parts[0], weight);
         }
 
-        std::vector<permission_level_weight> perm_levels(account_name code) const {
+        std::vector<permission_level_weight> perm_levels(account_name code, std::function<account_name(const std::string&)> name_resolver) const {
             std::vector<permission_level_weight> r;
             for (const auto& a: accounts) {
                 std::vector<string> parts;
                 auto perm_weight = split_weight(a);
                 split(parts, perm_weight.first, boost::algorithm::is_any_of("@"));
-                auto acc = parts[0].size() == 0 ? code : account_name(parts[0]);
+                auto acc = parts[0].size() == 0 ? code : name_resolver(parts[0]);
                 auto perm = account_name(parts.size() == 1 ? "" : parts[1].c_str());
                 r.emplace_back(permission_level_weight{permission_level{acc, perm}, perm_weight.second});
             }
@@ -82,8 +82,8 @@ struct genesis_info {
             return r;
         }
 
-        authority make_authority(const public_key_type& initial_key, account_name code) const {
-            return authority(threshold ? *threshold : 1, key_weights(initial_key), perm_levels(code), wait_weights());
+        authority make_authority(const public_key_type& initial_key, account_name code, std::function<account_name(const std::string&)> name_resolver) const {
+            return authority(threshold ? *threshold : 1, key_weights(initial_key), perm_levels(code, name_resolver), wait_weights());
         }
     };
 


### PR DESCRIPTION
Resolve #1067 
Allow to specify Golos usernames in created account's authorities.