### PR TITLE
Fix replaying of mainnet. #1094

### DIFF
--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -778,6 +778,16 @@ namespace cyberway { namespace chaindb {
         impl_->cache_.push(revision());
     }
 
+    void chaindb_controller::enable_bad_update() const {
+        // https://github.com/cyberway/cyberway/issues/1094
+        impl_->driver_.enable_bad_update();
+    }
+
+    void chaindb_controller::disable_bad_update() const {
+        // https://github.com/cyberway/cyberway/issues/1094
+        impl_->driver_.disable_bad_update();
+    }
+
     void chaindb_controller::close(const cursor_request& request) const {
         impl_->driver_.close(request);
     }

--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -933,9 +933,6 @@ namespace cyberway { namespace chaindb {
 
                     case write_operation::Remove:
                         build_find_document(pk_doc, *table_, op.object);
-                        if (op.find_revision >= start_revision) {
-                            pk_doc.append(kvp(names::revision_path, op.find_revision));
-                        }
                         break;
 
                     case write_operation::Unknown:

--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -842,10 +842,10 @@ namespace cyberway { namespace chaindb {
 
                 bulk_group_t_() = default;
 
-                bulk_group_t_(bulk_info_t_& info)
-                : remove(&info),
-                  update(&info),
-                  insert(&info) {
+                bulk_group_t_(write_ctx_t_& ctx, collection& undo_table)
+                : remove(&ctx.create_bulk_info(undo_table)),
+                  update(&ctx.create_bulk_info(undo_table)),
+                  insert(&ctx.create_bulk_info(undo_table)) {
                 }
             }; // struct bulk_group_t_;
 
@@ -853,8 +853,8 @@ namespace cyberway { namespace chaindb {
             write_ctx_t_(mongodb_driver_impl& impl)
             : impl_(impl),
               undo_table_(impl_.get_undo_db_table()),
-              complete_undo_bulk_(create_bulk_info(undo_table_)),
-              prepare_undo_bulk_(create_bulk_info(undo_table_)) {
+              complete_undo_bulk_(*this, undo_table_),
+              prepare_undo_bulk_(*this, undo_table_) {
             }
 
             void start_table(const table_info& table) {
@@ -972,7 +972,22 @@ namespace cyberway { namespace chaindb {
 
                 // no reasons to do reconnect, exception can happen after writing and it will fail whole writing-process
                 try {
-                    info.bulk.execute();
+                    auto res = info.bulk.execute();
+
+                    CYBERWAY_ASSERT(res, driver_open_exception,
+                        "MongoDB driver returns empty result of bulk execution");
+
+                    CYBERWAY_ASSERT(
+                        res->matched_count()  == info.op_cnt ||
+                        res->inserted_count() == info.op_cnt ||
+                        res->deleted_count()  == info.op_cnt ||
+                        res->modified_count() == info.op_cnt ||
+                        res->upserted_count() == info.op_cnt, driver_open_exception,
+                        "MongoDB driver returns bad result of bulk execution",
+                        ("op_cnt", info.op_cnt)("matched", res->matched_count())
+                        ("inserted", res->inserted_count())("modified", res->modified_count())
+                        ("deleted", res->deleted_count())("upserted", res->upserted_count()));
+
                 } catch (const mongocxx::bulk_write_exception& e) {
                     elog("MongoDB error on bulk write: ${code}, ${what}", ("code", e.code().value())("what", e.what()));
 

--- a/libraries/chain/chaindb/mongo_fail_driver.cpp
+++ b/libraries/chain/chaindb/mongo_fail_driver.cpp
@@ -13,6 +13,16 @@ namespace cyberway { namespace chaindb {
 
     mongodb_driver::~mongodb_driver() = default;
 
+    void mongodb_driver::enable_bad_update() const {
+        // https://github.com/cyberway/cyberway/issues/1094
+        NOT_SUPPORTED;
+    }
+
+    void mongodb_driver::disable_bad_update() const {
+        // https://github.com/cyberway/cyberway/issues/1094
+        NOT_SUPPORTED;
+    }
+
     std::vector<table_def> mongodb_driver::db_tables(const account_name&) const {
         NOT_SUPPORTED;
     }

--- a/libraries/chain/chaindb/undo_state.cpp
+++ b/libraries/chain/chaindb/undo_state.cpp
@@ -811,7 +811,7 @@ namespace cyberway { namespace chaindb {
                     journal_.write_undo(ctx, write_operation::remove(state.revision(), obj.second.clone_service()));
 
                     ritr->second.service.undo_rec = undo_record::OldValue;
-                    journal_.write_undo(ctx, write_operation::update(obj.second.service.revision,  ritr->second));
+                    journal_.write_undo(ctx, write_operation::update(ritr->second));
 
                     prev_state.old_values_.emplace(std::move(*ritr));
                     prev_state.removed_values_.erase(ritr);

--- a/libraries/chain/chaindb/undo_state.cpp
+++ b/libraries/chain/chaindb/undo_state.cpp
@@ -588,13 +588,13 @@ namespace cyberway { namespace chaindb {
                 ("table", get_full_table_name(table.info()))("scope", table.scope()));
 
             auto ctx = journal_.create_ctx(table.info());
+            cache_.clear_unsuccess(table.info());
 
             for (auto& obj: head.old_values_) {
                 auto undo_pk = obj.second.clone_service();
 
                 restore_undo_state(obj.second);
                 verifier_.verify(table.info(), obj.second);
-                cache_.clear_unsuccess(table.info());
                 cache_.emplace(table.info(), obj.second);
 
                 journal_.write(ctx,
@@ -603,7 +603,6 @@ namespace cyberway { namespace chaindb {
             }
 
             for (auto& obj: head.new_values_) {
-                cache_.clear_unsuccess(table.info());
                 cache_.remove(table.info(), obj.first);
                 driver_.skip_pk(table.info(), obj.first);
                 journal_.write(ctx,
@@ -616,7 +615,6 @@ namespace cyberway { namespace chaindb {
 
                 restore_undo_state(obj.second);
                 verifier_.verify(table.info(), obj.second);
-                cache_.clear_unsuccess(table.info());
                 cache_.emplace(table.info(), obj.second);
 
                 journal_.write(ctx,

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -127,6 +127,10 @@ namespace cyberway { namespace chaindb {
         void drop_db() const;
         void push_cache() const;
 
+        // https://github.com/cyberway/cyberway/issues/1094
+        void enable_bad_update() const;
+        void disable_bad_update() const;
+
         void close(const cursor_request&) const;
         void close_code_cursors(const account_name&) const;
 

--- a/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
+++ b/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
@@ -18,6 +18,9 @@ namespace cyberway { namespace chaindb {
     public:
         virtual ~driver_interface();
 
+        virtual void enable_bad_update() const = 0;
+        virtual void disable_bad_update() const = 0;
+
         virtual void drop_db() const = 0;
 
         virtual std::vector<table_def> db_tables(const account_name& code) const = 0;

--- a/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
@@ -16,6 +16,10 @@ namespace cyberway { namespace chaindb {
         mongodb_driver(journal&, string, string);
         ~mongodb_driver();
 
+        // https://github.com/cyberway/cyberway/issues/1094
+        void enable_bad_update() const override;
+        void disable_bad_update() const override;
+
         std::vector<table_def> db_tables(const account_name& code) const override;
         void create_index(const index_info&) const override;
         void drop_index(const index_info&) const override;


### PR DESCRIPTION
Resolve #1094:
- Don't check revision on updating and removing objects in MongoDB driver.
- Add checking of count of inserted/update/deleted objects in MongoDB driver.
- Fix replaying of blocks with bad receipts in mainnet.

In Mainnet there are 4 blocks with bad receipt:
- 121492
- 129069
- 189001
- 195902

These blocks were created after incorrect changing revisions in MongoDB.
To fix receipt for such blocks nodeos 
- Applies block by old update method
- Reverts it 
- Applies it again.
