### PR TITLE
Allow to dump permlinks of closed genesis posts #1097

### DIFF
--- a/programs/create-genesis/genesis_create.hpp
+++ b/programs/create-genesis/genesis_create.hpp
@@ -30,8 +30,9 @@ public:
     genesis_create();
     ~genesis_create();
 
-    void read_state(const bfs::path& state_file);
+    void read_state(const bfs::path& state_file, bool dump_closed_permlinks);
     void write_genesis(const bfs::path& out_file, const genesis_info&, const genesis_state&, const contracts_map&);
+    void dump_closed_permlinks(const bfs::path& out_file);
 
     // ee interface
     const genesis_info& get_info() const;


### PR DESCRIPTION
add optional `dump-closed-permlinks` option to `create-genesis` to set dump file. if set, only dump saved, no genesis created

Resolves #1097
