### PR TITLE
Disable onerror handler.

### DIFF
--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -1007,6 +1007,9 @@ namespace cyberway { namespace chaindb {
         }
 
         bool is_system_object(const cache_object& cache_obj) const {
+            if (is_fake_code(cache_obj.service().code)) {
+                return false;
+            }
             return !cache_obj.service().payer;
         }
 
@@ -1150,7 +1153,7 @@ namespace cyberway { namespace chaindb {
             }
 
             auto delta = state.object_ptr->service().size;
-            CYBERWAY_CACHE_ASSERT(UINT64_MAX - commited_size >= delta, "Commiting delta would overflow UINT64_MAX");
+            CYBERWAY_CACHE_ASSERT(!delta || UINT64_MAX - commited_size >= delta, "Commiting delta would overflow UINT64_MAX");
             commited_size += delta;
         }
 
@@ -1339,7 +1342,9 @@ namespace cyberway { namespace chaindb {
     ) const {
         assert(value);
         assert(size);
-        impl_->emplace_unsuccess(index, value, size, rpk);
+        if (!is_fake_code(index.code)) {
+            impl_->emplace_unsuccess(index, value, size, rpk);
+        }
     }
 
     void cache_map::clear_unsuccess(const table_info& table) const {

--- a/libraries/chain/chaindb/mongo_driver_utils.cpp
+++ b/libraries/chain/chaindb/mongo_driver_utils.cpp
@@ -322,6 +322,12 @@ namespace cyberway { namespace chaindb {
                             state.undo_rec = static_cast<undo_record>(itm.get_int32().value);
                             break;
                         }
+                        case 'v': {
+                            validate_field_name(names::undo_rev_field == key, src, itm);
+                            --field_cnt; // skip to count it
+                            state.undo_revision = itm.get_int64().value;
+                            break;
+                        }
                         default: {
                             validate_field_name(names::undo_ram_field == key, src, itm);
                             --field_cnt; // skip to count it
@@ -714,6 +720,7 @@ namespace cyberway { namespace chaindb {
         doc.append(kvp(names::service_field, [&](sub_document serv_doc) {
             serv_doc.append(kvp(names::undo_pk_field, to_decimal128(obj.service.undo_pk)));
             serv_doc.append(kvp(names::undo_rec_field, static_cast<int32_t>(obj.service.undo_rec)));
+            serv_doc.append(kvp(names::undo_rev_field, obj.service.undo_revision));
             serv_doc.append(kvp(names::undo_payer_field, to_decimal128(obj.service.undo_payer)));
             serv_doc.append(kvp(names::undo_size_field, static_cast<int32_t>(obj.service.undo_size)));
             serv_doc.append(kvp(names::code_field, to_decimal128(obj.service.code)));

--- a/libraries/chain/chaindb/names.cpp
+++ b/libraries/chain/chaindb/names.cpp
@@ -83,6 +83,7 @@ namespace cyberway { namespace chaindb {
     const string names::undo_size_field  = "usz";
     const string names::undo_ram_field   = "urm";
     const string names::undo_rec_field   = "uct";
+    const string names::undo_rev_field   = "uvs";
     const string names::revision_field   = "rev";
 
     const string names::payer_field      = "payer";

--- a/libraries/chain/chaindb/storage_calculator.cpp
+++ b/libraries/chain/chaindb/storage_calculator.cpp
@@ -168,6 +168,8 @@ namespace cyberway { namespace chaindb {
         int size = get_fixed_storage_usage(info, var);
         if (size) {
             return size;
+        } else if (is_fake_code(info.code)) {
+            return 0;
         }
 
         constexpr static int base_size  = 256; /* memory usage of structures in RAM */

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -860,6 +860,47 @@ struct controller_impl {
 //        return {trx_context.get_provided_bandwith(), trx_context.get_net_usage(), trx_context.get_cpu_usage()};
 //    }
 
+   bool is_softfail_transaction( const transaction_trace& trace ) const {
+       struct soft_fail_block {
+           block_id_type block_id;
+           fc::flat_set<transaction_id_type> trx_ids;
+       };
+
+       static fc::flat_map<uint32_t, soft_fail_block> blocks_with_soft_fail = {
+           { uint32_t(508310), {
+               block_id_type("0007c1967213d961df9d1934cc73ff9cacd68fe5c460e9fcae4fc019d3ec8b62"),
+               { transaction_id_type("f811650021f1048738b3c7c653c7459c529e3f95da2ae5ecad4bd9307187f56a")}}},
+           { uint32_t(528192), {
+               block_id_type("00080f40a2c957bd3fc039d8d88f06ea39517ae26ccd681e9f1caed4346e0b52"),
+               { transaction_id_type("a88270bb59e6933ca1b400d24c75917b656483abfde677c62cab17d026e9b99b")}}},
+           { uint32_t(542256), {
+               block_id_type("00084630b3a3c3bf8facac9f753613e1de85bf80332f40ad7a2a3c4778330928"),
+               { transaction_id_type("3766bcbf214bf7a8e8192c693e71e9b678638723c7be3daab7b675f11636918f")}}},
+           { uint32_t(542259), {
+               block_id_type("000846336f2f0053b6e4d0d6947cd443f5daabd8d682f5c6f87c714825aaa6ba"),
+               { transaction_id_type("81ff40bff8af6660043507356484d9cf4724d1c26c6752454c2dcca4e6abd47a")}}},
+           { uint32_t(551879), {
+               block_id_type("00086bc72fa03e2aad959ad3ef666f68c8e7d298c88e17e690d047f8c006501a"),
+               { transaction_id_type("ecd2badd55c72c14c7d86051bdf0c860013e6801b573c8b68e4021beed32c9dc")}}}
+       };
+
+       auto itr = blocks_with_soft_fail.find(trace.block_num);
+       if (blocks_with_soft_fail.end() == itr) {
+           return false;
+       }
+
+       EOS_ASSERT( *self.pending_producer_block_id() == itr->second.block_id, block_validate_exception,
+            "Bad ID (${head} != ${valid}) for the block ${num}",
+            ("head", head->id)("valid", itr->second.block_id)("num", *self.pending_producer_block_id()) );
+
+       auto ttr = itr->second.trx_ids.find(trace.id);
+       if (itr->second.trx_ids.end() == ttr) {
+           return false;
+       }
+
+       return true;
+   }
+
    transaction_trace_ptr push_scheduled_transaction( const generated_transaction_object& gto, fc::time_point deadline, const billed_bw_usage& billed )
    try {
       maybe_session undo_session;
@@ -919,7 +960,20 @@ struct controller_impl {
       trx_context.explicit_billed_ram_bytes = billed.explicit_usage;
       trx_context.billed_ram_bytes = billed.ram_bytes;
       trace = trx_context.trace;
+
+      // CyberWay speccific for disabled onerror handler
+      const bool is_softfailed_trx = is_softfail_transaction(*trace);
+      if (is_softfailed_trx) {
+          resource_limits.validate_storage_price(true);
+      }
+
       try {
+         auto restore_storage_price = fc::make_scoped_exit([&is_softfailed_trx, this](){
+            if( is_softfailed_trx ) {
+               resource_limits.validate_storage_price(false);
+            }
+         });
+
          //TODO: request bw, why provided?
          //auto bandwith_request_result = get_provided_bandwith(dtrx.actions, deadline);
          //trx_context.set_provided_bandwith(std::move(bandwith_request_result.bandwith));
@@ -963,7 +1017,11 @@ struct controller_impl {
 
       // Only subjective OR soft OR hard failure logic below:
 
-      if( gtrx.sender != account_name() && !controller::failure_is_subjective(*trace->except)) {
+// Disabled in CyberWay
+// the result receipt contains resource usage from two different transactions with different actors
+//   as result there is no way to validate the account resources on a validator node.
+//
+      if( is_softfailed_trx ) {
          // Attempt error handling for the generated transaction.
 
          auto error_trace = apply_onerror( gtrx, trx_context, deadline,

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -378,7 +378,7 @@ struct controller_impl {
          }
          replay_push_block( next, controller::block_status::irreversible );
          if( next->block_num() % 500 == 0 ) {
-            if( next->block_num() % 10000 && skip_session ) {
+            if( (next->block_num() % 10000) == 0 && skip_session ) {
                chaindb.apply_all_changes();
             }
             ilog( "${n} of ${head}", ("n", next->block_num())("head", blog_head->block_num()) );

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1389,6 +1389,25 @@ struct controller_impl {
       } );
    }
 
+   bool has_bad_transaction(const signed_block_ptr& block) const {
+      // TODO: Remove after network recovering
+
+      if (block->block_num() < 553022 || block->block_num() > 563023) {
+         return false;
+      }
+
+      for (auto& receipt: block->transactions) {
+         if( receipt.trx.contains<transaction_id_type>() &&
+            receipt.status == transaction_receipt_header::soft_fail &&
+            receipt.trx.get<transaction_id_type>() == transaction_id_type("b98c90c35804a78f78f0ad1ab08434123afbabd413d1981ffb5dec540373cf51")
+         ) {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
    void push_block( std::future<block_state_ptr>& block_state_future ) {
       controller::block_status s = controller::block_status::complete;
       EOS_ASSERT(!pending, block_validate_exception, "it is not valid to push a block when there is a pending block");
@@ -1399,6 +1418,11 @@ struct controller_impl {
       try {
          block_state_ptr new_header_state = block_state_future.get();
          auto& b = new_header_state->block;
+         if (has_bad_transaction(b)) {
+            // TODO: Remove after network recovering
+            return;
+         }
+
          emit( self.pre_accepted_block, b );
 
          fork_db.add( new_header_state, false );

--- a/libraries/chain/genesis/genesis_import.cpp
+++ b/libraries/chain/genesis/genesis_import.cpp
@@ -31,9 +31,8 @@ struct genesis_import::impl final {
     }
 
     void apply_db_changes(bool force = false) {
-        if (force || (++db_updates & 0xFFF) == 0) {
+        if (force || (++db_updates % 10000) == 0) {
             db.apply_all_changes();
-            db.push_cache();
         }
     }
 

--- a/libraries/chain/include/cyberway/chaindb/names.hpp
+++ b/libraries/chain/include/cyberway/chaindb/names.hpp
@@ -21,6 +21,7 @@ namespace cyberway { namespace chaindb {
 
         static const string next_pk_field;
         static const string undo_pk_field;
+        static const string undo_rev_field;
         static const string undo_rec_field;
         static const string undo_payer_field;
         static const string undo_size_field;

--- a/libraries/chain/include/cyberway/chaindb/names.hpp
+++ b/libraries/chain/include/cyberway/chaindb/names.hpp
@@ -59,6 +59,10 @@ namespace cyberway { namespace chaindb {
         return (code.empty()) || (code.value == config::system_account_name);
     }
 
+    inline bool is_fake_code(const account_name& code) {
+        return !code.empty() && ((N(z) & code.value) == N(.));
+    }
+
     inline string get_code_name(string name, const account_name& code) {
         if (!is_system_code(code)) name.append(db_name_to_string(code.value));
         return name;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -125,14 +125,14 @@ namespace eosio { namespace chain {
                    || (code == block_usage_exceeded::code_value)
                    || (code == deadline_exception::code_value)
                    || (code == timer_off_exception::code_value)
+                   || (code == account_resources_exceeded::code_value)
                    || (code == explicitly_billed_exception::code_value);
          }
 
          static bool scheduled_failure_is_subjective(const fc::exception& e, bool producing) {
             auto code = e.code();
             bool is_subj = failure_is_subjective(e);
-            return is_subj || (producing && ((code == tx_subjective_usage_exceeded::code_value)
-                                          || (code == account_resources_exceeded::code_value)));
+            return is_subj || (producing && (code == tx_subjective_usage_exceeded::code_value));
          }
 
          struct config {

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -89,8 +89,13 @@ namespace resource_limits {
 
          std::vector<uint64_t> get_account_usage(const account_name& account) const;
 
+         void validate_storage_price(bool value) {
+             _validate_storage_price = value;
+         }
+
       private:
          chaindb_controller& _chaindb;
+         bool _validate_storage_price = false;
    };
 } } } /// eosio::chain
 

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -211,7 +211,7 @@ void resource_limits_manager::add_storage_usage(
       _chaindb.modify( usage, [&]( auto& u ) {
           u.accumulators[STORAGE].add(a.second, time_slot, config.account_usage_average_windows[STORAGE]);
       });
-      if( validate ) {
+      if( validate && (a.second > 0 || _validate_storage_price)) {
          get_account_balance(pending_block_time, a.first, prices, true);
       }
    }

--- a/unittests/currency_tests.cpp
+++ b/unittests/currency_tests.cpp
@@ -515,6 +515,9 @@ BOOST_FIXTURE_TEST_CASE( test_deferred_failure, currency_tester ) try {
       BOOST_REQUIRE_EQUAL(1, index.size());
       BOOST_REQUIRE_EQUAL(false, chain_has_transaction(deferred_id));
    }
+   // onerror handler is removed in CyberWay
+   return;
+
 
    fc::time_point expected_redelivery = control->pending_block_time() + fc::seconds(10);
    // First deferred transaction should be retired in this block.


### PR DESCRIPTION
Resolve #1106:
- Disable onerror handler
- Skip blocks with bad transaction for fast network recovering (should be removed later).

Resolve #1105:
- Exception account_resource_exceeded is subjective

Resolve #1103:
- Fix reverting to LIB

Resolve #1104:
- Don't add fake objects to cache.
