### PR TITLE
Restore multi_index tests #352

### DIFF
--- a/.buildkite/steps/deploy-unit_test.sh
+++ b/.buildkite/steps/deploy-unit_test.sh
@@ -15,7 +15,7 @@ docker-compose up -d mongo
 
 # Run unit-tests
 sleep 10s
-docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l test_suite -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!bootseq_tests/*" -t "!eosio_system_tests/*" -t "!multi_index_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*"'
+docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l test_suite -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!bootseq_tests/*" -t "!eosio_system_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*"'
 result=$?
 
 docker-compose down

--- a/contracts/multi_index_test/multi_index_test.abi
+++ b/contracts/multi_index_test/multi_index_test.abi
@@ -1,7 +1,27 @@
 {
-  "version": "eosio::abi/1.0",
+  "version": "cyberway::abi/1.0",
   "types": [],
-  "structs": [{
+  "structs": [
+   {
+      "name": "limit_order",
+      "base": "",
+      "fields": [
+         {"name": "id",   "type": "uint64"},
+         {"name": "padding",   "type": "uint64"},
+         {"name": "price",   "type": "uint128"},
+         {"name": "expiration",   "type": "uint64"},
+         {"name": "owner",   "type": "name"}
+      ]
+   },
+   {
+      "name": "test_asset",
+      "base": "",
+      "fields": [
+         {"name": "id",   "type": "uint64"},
+         {"name": "val",   "type": "asset"}
+      ]
+   },
+   {
       "name": "trigger",
       "base": "",
       "fields": [
@@ -11,10 +31,37 @@
   ],
   "actions": [{
       "name": "trigger",
-      "type": "trigger",
-      "ricaridian_contract": ""
+      "type": "trigger"
     }
   ],
-  "tables": [],
+  "tables": [{
+      "name": "orders",
+      "type": "limit_order",
+      "indexes": [{
+          "name": "primary",
+          "unique": true,
+          "orders": [{"field": "id", "order": "asc"}]
+      }, {
+          "name": "byexp",
+          "unique": false,
+          "orders": [{"field": "expiration", "order": "asc"}]
+      }, {
+          "name": "byprice",
+          "unique": false,
+          "orders": [{"field": "price", "order": "asc"}]
+      }]
+    }, {
+      "name": "test1",
+      "type": "test_asset",
+      "indexes": [{
+          "name": "primary",
+          "unique": true,
+          "orders": [{"field": "id", "order": "asc"}]
+      }, {
+          "name": "byval",
+          "unique": false,
+          "orders": [{"field": "val", "order": "asc"}]
+      }]
+    }],
   "abi_extensions": []
 }


### PR DESCRIPTION
Resolve #352:
- Removed EOSIO_SERIALIZE because it works wrong here and we not using it.
- Replaced key256 with asset (sense is same - test the sorting).
