### PR TITLE
Added full authorities to EE-genesis #1120

### DIFF
--- a/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
@@ -211,6 +211,11 @@ static abi_def create_accounts_abi() {
     abi_def abi;
     abi.version = ABI_VERSION;
 
+    // copied just for "copy-paste" compatibility with eosio_contract_abi.cpp
+    abi.types.push_back( type_def{"account_name", "name"} );
+    abi.types.push_back( type_def{"permission_name", "name"} );
+    abi.types.push_back( type_def{"weight_type", "uint16"} );
+
     abi.structs.emplace_back( struct_def {
         "domain_info", "", {
             {"owner", "name"},
@@ -219,21 +224,47 @@ static abi_def create_accounts_abi() {
         }
     });
 
-    abi.structs.emplace_back( struct_def {
-       "key_weight", "", {
-            {"key", "public_key"},
-            {"weight", "uint16"}
-        }
-    });
+   abi.structs.emplace_back( struct_def {
+      "permission_level", "", {
+         {"actor", "account_name"},
+         {"permission", "permission_name"}
+      }
+   });
+   abi.structs.emplace_back( struct_def {
+      "key_weight", "", {
+         {"key", "public_key"},
+         {"weight", "weight_type"}
+      }
+   });
+   abi.structs.emplace_back( struct_def {
+      "permission_level_weight", "", {
+         {"permission", "permission_level"},
+         {"weight", "weight_type"}
+      }
+   });
+   abi.structs.emplace_back( struct_def {
+      "wait_weight", "", {
+         {"wait_sec", "uint32"},
+         {"weight", "weight_type"}
+      }
+   });
+   abi.structs.emplace_back( struct_def {
+      "authority", "", {
+         {"threshold", "uint32"},
+         {"keys", "key_weight[]"},
+         {"accounts", "permission_level_weight[]"},
+         {"waits", "wait_weight[]"}
+      }
+   });
 
     abi.structs.emplace_back( struct_def {
         "account_info", "", {
             {"creator", "name"},
             {"owner", "name"},
             {"name", "string"},
-            {"owner_keys", "key_weight[]"},
-            {"active_keys", "key_weight[]"},
-            {"posting_keys", "key_weight[]"},
+            {"owner_auth", "authority"},
+            {"active_auth", "authority"},
+            {"posting_auth", "authority"},
             {"created", "time_point_sec"},
             {"last_update", "time_point_sec"},
             {"reputation", "int64"},

--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -350,15 +350,15 @@ struct genesis_create::genesis_create_impl final {
             const auto own = convert_authority(config::owner_name, a.owner, recovery_acc);
             const auto act = convert_authority(config::active_name, a.active);
             const auto post = convert_authority(posting_auth_name, a.posting);
+            _exp_info.account_infos[a.account.id] = mvo
+                ("owner_auth", own)
+                ("active_auth", act)
+                ("posting_auth", post);
 
             auto name = name_by_acc(a.account);
             const auto& owner  = store_permission(name, config::owner_name, 0, own, usage_id++);
             const auto& active = store_permission(name, config::active_name, owner.id, act, usage_id++);
             const auto& posting= store_permission(name, posting_auth_name, active.id, post, usage_id++);
-            _exp_info.account_infos[a.account.id] = mvo
-                ("owner_keys", own.keys)
-                ("active_keys", act.keys)
-                ("posting_keys", post.keys);
 
             auto itr = std::find_if(_info.transit_account_authorities.begin(), _info.transit_account_authorities.end(),
                     [&](const auto& acc) {return acc.name == name;});


### PR DESCRIPTION
Resolve #1120.

### Note: IO should be noticed about any fields change (as experience shows).

Example of resulting account:
```
        "creator": "gls",
        "owner": "qvqwiubdbbzt",
        "name": "imranj131",
        "owner_auth": {
            "threshold": 3,
            "keys": [{
                "key": "GLS5cr2PV5zxat7XF982gQ4L9G8YhwjUamCj9tuyx1g4dFHNXLnfE",
                "weight": 2
            }],
            "accounts": [{
                "permission": {
                    "actor": "2spfd3u5twke",
                    "permission": "owner"
                },
                "weight": 1
            }],
            "waits": [{
                "wait_sec": 2592000,
                "weight": 1
            }]
        },
        "active_auth": {
            "threshold": 1,
            "keys": [{
                "key": "GLS84kG6mLvYZPXk1WUE3gbbaqbvMNTgsvprRQ9fPfHLtmqoKa678",
                "weight": 1
            }],
            "accounts": [],
            "waits": []
        },
        "posting_auth": {
            "threshold": 1,
            "keys": [{
                "key": "GLS7d5JDiocc6ZeswnnxiA1YjUuTzjDbGHyzUuoycuyaK7Ea45r76",
                "weight": 1
            }],
            "accounts": [],
            "waits": []
        },
        "created": "1970-01-01T00:00:00.000",
        "last_update": "1970-01-01T00:00:00.000",
        "reputation": 0,
        "json_metadata": "{created_at: 'GENESIS'}"
```