### PR TITLE
Option to skip mainnet blocks #1124

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1394,25 +1394,6 @@ struct controller_impl {
       } );
    }
 
-   bool has_bad_transaction(const signed_block_ptr& block) const {
-      // TODO: Remove after network recovering
-
-      if (block->block_num() < 553022 || block->block_num() > 563023) {
-         return false;
-      }
-
-      for (auto& receipt: block->transactions) {
-         if( receipt.trx.contains<transaction_id_type>() &&
-            receipt.status == transaction_receipt_header::soft_fail &&
-            receipt.trx.get<transaction_id_type>() == transaction_id_type("b98c90c35804a78f78f0ad1ab08434123afbabd413d1981ffb5dec540373cf51")
-         ) {
-            return true;
-         }
-      }
-
-      return false;
-   }
-
    void push_block( std::future<block_state_ptr>& block_state_future ) {
       controller::block_status s = controller::block_status::complete;
       EOS_ASSERT(!pending, block_validate_exception, "it is not valid to push a block when there is a pending block");
@@ -1423,10 +1404,6 @@ struct controller_impl {
       try {
          block_state_ptr new_header_state = block_state_future.get();
          auto& b = new_header_state->block;
-         if (has_bad_transaction(b)) {
-            // TODO: Remove after network recovering
-            return;
-         }
 
          emit( self.pre_accepted_block, b );
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -293,6 +293,7 @@ namespace eosio { namespace chain {
          bool skip_db_sessions( )const;
          bool skip_db_sessions( block_status bs )const;
          bool skip_trx_checks()const;
+         void skip_bad_blocks_check();
 
          bool contracts_console()const;
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -429,8 +429,11 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
          ("chaindb_sys_name", bpo::value<string>()->default_value("_CYBERWAY_"),
           "Prefix for database names")
          ("genesis-data", bpo::value<bfs::path>(),
-             "The location of the Genesis state file (absolute path or relative to the current directory)")
-         ("trusted-producer", bpo::value<vector<string>>()->composing(), "Indicate a producer whose blocks headers signed by it will be fully validated, but transactions in those validated blocks will be trusted.")
+          "The location of the Genesis state file (absolute path or relative to the current directory)")
+         ("trusted-producer", bpo::value<vector<string>>()->composing(),
+          "Indicate a producer whose blocks headers signed by it will be fully validated, but transactions in those validated blocks will be trusted.")
+         ("skip-bad-blocks-check", bpo::bool_switch()->default_value(false),
+          "skip checking on bad blocks from MainNet, useful for TestNets")
          ;
 
 // TODO: rate limiting
@@ -851,6 +854,10 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
       my->chain.emplace( *my->chain_config );
       my->chain_id.emplace( my->chain->get_chain_id());
       std::cout << "chain_id: " << my->chain_id->str() << std::endl;
+
+      if ( options.count("skip-bad-blocks-check") ) {
+         my->chain->skip_bad_blocks_check();
+      }
 
       // set up method providers
       my->get_block_by_number_provider = app().get_method<methods::get_block_by_number>().register_provider(


### PR DESCRIPTION
Resolve #1124:
- Add option to skip bad blocks from MainNet.

Additional changes:
- Remove code, which was used for fast network recovering.
