### PR TITLE
Refactor undo on failing on inserting unique records. #1137

### DIFF
--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -538,8 +538,14 @@ namespace cyberway { namespace chaindb {
         }
 
         void undo_revision(const revision_t revision) {
+            auto reset_undo_restorer = fc::make_scoped_exit([this](){
+                driver_.disable_undo_restore();
+            });
+
+            driver_.enable_undo_restore();
             undo_.undo(revision);
             cache_.undo_session(revision);
+            driver_.apply_all_changes();
         }
 
         void commit_revision(const revision_t revision) {
@@ -778,14 +784,14 @@ namespace cyberway { namespace chaindb {
         impl_->cache_.push(revision());
     }
 
-    void chaindb_controller::enable_bad_update() const {
+    void chaindb_controller::enable_rev_bad_update() const {
         // https://github.com/cyberway/cyberway/issues/1094
-        impl_->driver_.enable_bad_update();
+        impl_->driver_.enable_rev_bad_update();
     }
 
-    void chaindb_controller::disable_bad_update() const {
+    void chaindb_controller::disable_rev_bad_update() const {
         // https://github.com/cyberway/cyberway/issues/1094
-        impl_->driver_.disable_bad_update();
+        impl_->driver_.disable_rev_bad_update();
     }
 
     void chaindb_controller::close(const cursor_request& request) const {

--- a/libraries/chain/chaindb/mongo_fail_driver.cpp
+++ b/libraries/chain/chaindb/mongo_fail_driver.cpp
@@ -13,13 +13,21 @@ namespace cyberway { namespace chaindb {
 
     mongodb_driver::~mongodb_driver() = default;
 
-    void mongodb_driver::enable_bad_update() const {
+    void mongodb_driver::enable_rev_bad_update() const {
         // https://github.com/cyberway/cyberway/issues/1094
         NOT_SUPPORTED;
     }
 
-    void mongodb_driver::disable_bad_update() const {
+    void mongodb_driver::disable_rev_bad_update() const {
         // https://github.com/cyberway/cyberway/issues/1094
+        NOT_SUPPORTED;
+    }
+
+    void mongodb_driver::enable_undo_restore() const {
+        NOT_SUPPORTED;
+    }
+
+    void mongodb_driver::disable_undo_restore() const {
         NOT_SUPPORTED;
     }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1551,7 +1551,7 @@ struct controller_impl {
            set_revision(head->block_num - 1);
        }
 
-       chaindb.enable_bad_update();
+       chaindb.enable_rev_bad_update();
 
        auto& b = head->block;
        auto  b_time = block_timestamp_type(b->timestamp.to_time_point() - fc::seconds(3));
@@ -1588,7 +1588,7 @@ struct controller_impl {
        chaindb.apply_all_changes();
        pending.reset();
        chaindb.apply_all_changes();
-       chaindb.disable_bad_update();
+       chaindb.disable_rev_bad_update();
 
        if (skip_sessions) {
            set_revision(head->block_num);

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -128,8 +128,8 @@ namespace cyberway { namespace chaindb {
         void push_cache() const;
 
         // https://github.com/cyberway/cyberway/issues/1094
-        void enable_bad_update() const;
-        void disable_bad_update() const;
+        void enable_rev_bad_update() const;
+        void disable_rev_bad_update() const;
 
         void close(const cursor_request&) const;
         void close_code_cursors(const account_name&) const;

--- a/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
+++ b/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
@@ -18,8 +18,11 @@ namespace cyberway { namespace chaindb {
     public:
         virtual ~driver_interface();
 
-        virtual void enable_bad_update() const = 0;
-        virtual void disable_bad_update() const = 0;
+        virtual void enable_rev_bad_update() const = 0;
+        virtual void disable_rev_bad_update() const = 0;
+
+        virtual void enable_undo_restore() const = 0;
+        virtual void disable_undo_restore() const = 0;
 
         virtual void drop_db() const = 0;
 

--- a/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
@@ -17,8 +17,11 @@ namespace cyberway { namespace chaindb {
         ~mongodb_driver();
 
         // https://github.com/cyberway/cyberway/issues/1094
-        void enable_bad_update() const override;
-        void disable_bad_update() const override;
+        void enable_rev_bad_update() const override;
+        void disable_rev_bad_update() const override;
+
+        void enable_undo_restore() const override;
+        void disable_undo_restore() const override;
 
         std::vector<table_def> db_tables(const account_name& code) const override;
         void create_index(const index_info&) const override;


### PR DESCRIPTION
Resolve #1137:
- Disable checking of updated rows in MongoDB driver on undo
- Apply all changes on undo, because undo in DB can happens in different cases which requires checking of applied operations: after pushing transaction or after applying block
