### PR TITLE
Add information about executed action when assert occurs #1141

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -81,6 +81,7 @@ void apply_context::exec_one( action_trace& trace )
       trace.receipt = r; // fill with known data
       trace.except = e;
       finalize_trace( trace, start );
+      FC_RETHROW_EXCEPTION(e, error, "Executed action ${act}", ("e",e)("act",act));
       throw;
    }
 


### PR DESCRIPTION
Resolve #1141 

Action information printed like this:
```
$ cleos push action cyber.token open '["tech","3,CYBER","acc"]' -p tech
Error 3090004: Missing required authority
Ensure that you have the related authority inside your transaction!;
If you are currently using 'cleos push action' command, try to add the relevant authority using -p option.
Error Details:
missing authority of acc
pending console output: 
Executed action {"account":"cyber.token","name":"open","authorization":[{"actor":"tech","permission":"active"}],"data":"0000000000d090ca03435942455200000000000000001032"}
```