### PR TITLE
fixed the nodeos fail on restart in debug mode

### DIFF
--- a/libraries/chain/chaindb/abi_info.cpp
+++ b/libraries/chain/chaindb/abi_info.cpp
@@ -50,6 +50,7 @@ namespace cyberway { namespace chaindb {
         table_info generate_table_info(const abi_info& abi, const table_def& table) {
             table_info info(abi.code(), abi.code());
             info.table = &table;
+            info.pk_order = abi.find_pk_order(table);
             return info;
         }
 


### PR DESCRIPTION
Resolve #1175 : the generate_table_info method also intializes the pk_order feild

