### PR TITLE
Fix linking problem to re-enable unittests on macos #1208

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,4 @@
-if(NOT APPLE)
-  add_subdirectory( core_unit_tests )
-endif()
-
+add_subdirectory( core_unit_tests )
 #add_subdirectory( plugin_unit_tests )
 #add_subdirectory( chaindb )
 add_subdirectory( test_api )

--- a/tests/core_unit_tests/main.cpp
+++ b/tests/core_unit_tests/main.cpp
@@ -4,7 +4,8 @@
  */
 #include <cstdlib>
 #include <iostream>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_monitor.hpp>
 #include <fc/log/logger.hpp>
 #include <eosio/chain/exceptions.hpp>
 


### PR DESCRIPTION
Resolves #1208

