### PR TITLE
Support optional structs in ABI #1218

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -488,6 +488,12 @@ namespace eosio { namespace chain {
            _variant_to_binary(fundamental_type(rtype), var, ds, ctx);
            ++i;
          }
+      } else if( is_optional(rtype) ) {
+         char flag = !var.is_null();
+         fc::raw::pack(ds, flag);
+         if( flag ) {
+            _variant_to_binary(fundamental_type(rtype), var, ds, ctx);
+         }
       } else if( (v_itr = variants.find(rtype)) != variants.end() ) {
          ctx.hint_variant_type_if_in_array( v_itr );
          auto& v = v_itr->second;

--- a/tests/core_unit_tests/abi_tests.cpp
+++ b/tests/core_unit_tests/abi_tests.cpp
@@ -2738,4 +2738,24 @@ BOOST_AUTO_TEST_CASE(abi_deserialize_detailed_error_messages)
    } FC_LOG_AND_RETHROW()
 }
 
+BOOST_AUTO_TEST_CASE(serialize_optional_struct_type)
+{
+   auto abi = R"({
+      "version": "cyberway::abi/1.1",
+      "structs": [
+         {"name": "s", "base": "", "fields": [
+            {"name": "i0", "type": "int8"}
+         ]},
+      ],
+   })";
+
+   try {
+      abi_serializer abis( fc::json::from_string(abi).as<abi_def>(), max_serialization_time );
+
+      verify_round_trip_conversion(abis, "s?", R"({"i0":5})", "0105");
+      verify_round_trip_conversion(abis, "s?", R"(null)", "00");
+
+   } FC_LOG_AND_RETHROW()
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Resolve #1218.
- Code from EOS + change eosio 1.0 abi version to cyberway 1.1.