### PR TITLE
Increment p2p protocol version for address advertising #1239

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -336,8 +336,9 @@ namespace eosio {
     */
    constexpr uint16_t proto_base = 0;
    constexpr uint16_t proto_explicit_sync = 1;
+   constexpr uint16_t proto_address_advertising = 2;
 
-   constexpr uint16_t net_version = proto_explicit_sync;
+   constexpr uint16_t net_version = proto_address_advertising;
 
    struct transaction_state {
       transaction_id_type id;


### PR DESCRIPTION
Resolve #1239:
- Added new protocol version constant - `proto_address_advertising` - and incremented `net_version` to this constant (so client now sends handshakes with new version).
- For check is client supports address advertising, we can just check `c->protocol_version >= proto_address_advertising` when sending.
This issue implemented using "proto_xxx" versioning system which was already implemented in plugin, and don't requires a special solution.