### PR TITLE
P2P - Send addresses in address_message #1242

### DIFF
--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -135,6 +135,10 @@ namespace eosio {
    struct address_request_message {
    };
 
+   struct address_message {
+      std::vector<std::string> addresses;
+   };
+
    using net_message = static_variant<handshake_message,
                                       chain_size_message,
                                       go_away_message,
@@ -144,7 +148,8 @@ namespace eosio {
                                       sync_request_message,
                                       signed_block,         // which = 7
                                       packed_transaction,   // which = 8
-                                      address_request_message>;
+                                      address_request_message,
+                                      address_message>;
 
 } // namespace eosio
 
@@ -164,6 +169,7 @@ FC_REFLECT( eosio::notice_message, (known_trx)(known_blocks) )
 FC_REFLECT( eosio::request_message, (req_trx)(req_blocks) )
 FC_REFLECT( eosio::sync_request_message, (start_block)(end_block) )
 FC_REFLECT( eosio::address_request_message, )
+FC_REFLECT( eosio::address_message, (addresses) )
 
 /**
  *

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -212,6 +212,7 @@ namespace eosio {
       void handle_message(const connection_ptr& c, const request_message& msg);
       void handle_message(const connection_ptr& c, const sync_request_message& msg);
       void handle_message(const connection_ptr& c, const address_request_message& msg);
+      void handle_message(const connection_ptr& c, const address_message& msg);
       void handle_message(const connection_ptr& c, const signed_block& msg) = delete; // signed_block_ptr overload used instead
       void handle_message(const connection_ptr& c, const signed_block_ptr& msg);
       void handle_message(const connection_ptr& c, const packed_transaction& msg) = delete; // packed_transaction_ptr overload used instead
@@ -2474,6 +2475,14 @@ namespace eosio {
    }
 
    void net_plugin_impl::handle_message(const connection_ptr& c, const address_request_message& msg) {
+      address_message amsg;
+      for( auto& con : connections ) {
+         amsg.addresses.push_back(con->peer_addr);
+      }
+      c->enqueue(amsg);
+   }
+
+   void net_plugin_impl::handle_message(const connection_ptr& c, const address_message& msg) {
    }
 
    size_t calc_trx_size( const packed_transaction_ptr& trx ) {


### PR DESCRIPTION
Partly resolve #1242:
- Send addresses of connected peers in `address_message`.
