### PR TITLE
Fix gray connections #1271

### DIFF
--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -52,7 +52,8 @@ namespace eosio {
     validation, ///< the peer sent a block that failed validation
     benign_other, ///< reasons such as a timeout. not fatal but warrant resetting
     fatal_other, ///< a catch-all for errors we don't have discriminated
-    authentication ///< peer failed authenicatio
+    authentication, ///< peer failed authentication
+    gray_peer ///< gray peer sent message which wasn't should
   };
 
   constexpr auto reason_str( go_away_reason rsn ) {
@@ -69,6 +70,7 @@ namespace eosio {
     case authentication : return "authentication failure";
     case fatal_other : return "some other failure";
     case benign_other : return "some other non-fatal condition";
+    case gray_peer : return "gray peer connection";
     default : return "some crazy reason";
     }
   }


### PR DESCRIPTION
Resolve #1271:
- Forbidden receiving messages from gray connections.
- Added possibility for connection to know it is gray - added marker into handshake_message's agent field (unfortunately, handshake_message haven't user_data field in different to Golos Blockchain implementation).