### PR TITLE
Add `checkversion`-action to check abi or code version #1299

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -241,6 +241,7 @@ struct controller_impl {
    SET_APP_HANDLER(cyber, cyber, newaccount);
    SET_APP_HANDLER(cyber, cyber, setcode);
    SET_APP_HANDLER(cyber, cyber, setabi);
+   SET_APP_HANDLER(cyber, cyber, checkversion);
    SET_APP_HANDLER(cyber, cyber, updateauth);
    SET_APP_HANDLER(cyber, cyber, deleteauth);
    SET_APP_HANDLER(cyber, cyber, linkauth);

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -277,6 +277,23 @@ void apply_cyber_setabi(apply_context& context) {
 //   }
 }
 
+void apply_cyber_checkversion(apply_context& context) {
+    auto& chaindb = context.chaindb;
+    auto  act = context.act.data_as<checkversion>();
+
+    const auto& account = chaindb.get<account_object>(act.account);
+    EOS_ASSERT(act.code_version.valid() || act.abi_version.valid(), action_validate_exception,
+            "At least one of code or abi version must be specified");
+
+    if(act.code_version.valid()) {
+        EOS_ASSERT(account.code_version == *act.code_version, action_validate_exception, "Wrong code version");
+    }
+
+    if(act.abi_version.valid()) {
+        EOS_ASSERT(account.abi_version == *act.abi_version, action_validate_exception, "Wrong abi version");
+    }
+}
+
 void apply_cyber_updateauth(apply_context& context) {
 
    auto update = context.act.data_as<updateauth>();

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -610,6 +610,14 @@ abi_def eosio_contract_abi(abi_def eos_abi)
    });
 
    eos_abi.structs.emplace_back( struct_def {
+      "checkversion", "", {
+        {"account", "account_name"},
+        {"abi_version", "checksum256?"},
+        {"code_version", "checksum256?"}
+      }
+   });
+
+   eos_abi.structs.emplace_back( struct_def {
       "updateauth", "", {
          {"account", "account_name"},
          {"permission", "permission_name"},
@@ -691,6 +699,7 @@ abi_def eosio_contract_abi(abi_def eos_abi)
    eos_abi.actions.push_back( action_def{name("newaccount"), "newaccount"} );
    eos_abi.actions.push_back( action_def{name("setcode"), "setcode"} );
    eos_abi.actions.push_back( action_def{name("setabi"), "setabi"} );
+   eos_abi.actions.push_back( action_def{name("checkversion"), "checkversion"} );
    eos_abi.actions.push_back( action_def{name("updateauth"), "updateauth"} );
    eos_abi.actions.push_back( action_def{name("deleteauth"), "deleteauth"} );
    eos_abi.actions.push_back( action_def{name("linkauth"), "linkauth"} );

--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -52,6 +52,20 @@ struct setabi {
    }
 };
 
+struct checkversion {
+    account_name                    account;
+    optional<digest_type>           abi_version;
+    optional<digest_type>           code_version;
+
+    static account_name get_account() {
+        return config::system_account_name;
+    }
+
+    static action_name get_name() {
+        return N(checkversion);
+    }
+};
+
 
 struct updateauth {
    account_name                      account;
@@ -159,6 +173,7 @@ struct onerror {
 FC_REFLECT( eosio::chain::newaccount                       , (creator)(name)(owner)(active) )
 FC_REFLECT( eosio::chain::setcode                          , (account)(vmtype)(vmversion)(code) )
 FC_REFLECT( eosio::chain::setabi                           , (account)(abi) )
+FC_REFLECT( eosio::chain::checkversion                     , (account)(abi_version)(code_version) )
 FC_REFLECT( eosio::chain::updateauth                       , (account)(permission)(parent)(auth) )
 FC_REFLECT( eosio::chain::deleteauth                       , (account)(permission) )
 FC_REFLECT( eosio::chain::linkauth                         , (account)(code)(type)(requirement) )

--- a/libraries/chain/include/eosio/chain/eosio_contract.hpp
+++ b/libraries/chain/include/eosio/chain/eosio_contract.hpp
@@ -22,6 +22,7 @@ namespace eosio { namespace chain {
    void apply_cyber_unlinkauth(apply_context&);
    void apply_cyber_setcode(apply_context&);
    void apply_cyber_setabi(apply_context&);
+   void apply_cyber_checkversion(apply_context&);
    void apply_cyber_canceldelay(apply_context&);
    ///@}  end action handlers
 


### PR DESCRIPTION
Resolve #1299

Add `checkversion`-action in bios contract (`cyber` account) which allows the user to verify the code or abi version.
Action has signature:
```cyber::checkversion(name account, optional<checksum256> code_version, optional<checksum256> abi_version)``` and allows one to specify for verification only one of the versions (but at least one must be present).
