### PR TITLE
Fix throwing error on bad pk

### DIFF
--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -691,7 +691,7 @@ namespace cyberway { namespace chaindb {
             CYBERWAY_ASSERT(primary_key::from_variant(table, obj.value).value() == obj.pk(), primary_key_exception,
                 "Object '${obj}' from the table ${table} has wrong value '${pk}' in the primary key",
                 ("obj", obj.value)
-                ("pk", primary_key::from_value(table, obj.pk()).to_string())
+                ("pk", primary_key::from_raw(table, obj.pk()).to_string())
                 ("table", get_full_table_name(table)));
         }
 

--- a/libraries/chain/include/cyberway/chaindb/typed_name.hpp
+++ b/libraries/chain/include/cyberway/chaindb/typed_name.hpp
@@ -85,6 +85,10 @@ namespace cyberway { namespace chaindb {
             return typed_name::from_value(kind_from_table(info), std::forward<Args>(args)...);
         }
 
+        static primary_key from_raw(const table_info& info, value_type value) {
+            return typed_name::create(kind_from_table(info), value);
+        }
+
         static primary_key from_string(const table_info&, const string&);
 
         static primary_key from_table(const table_info&, value_type);


### PR DESCRIPTION
`primary_key::from_value` throws exception if input type of pk is wrong.
To resolve the incorrect behavior the new method `primary_key::from_raw` is added.