### PR TITLE
Remove scope skipping in mongodb sort document. #1329

### DIFF
--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -330,7 +330,7 @@ namespace cyberway { namespace chaindb {
             document sort;
             auto order = static_cast<int>(direction_);
 
-            if (!is_noscope_table(index) && !ignore_scope(index)) {
+            if (!is_noscope_table(index)) {
                 sort.append(kvp(names::scope_path, order));
             }
 


### PR DESCRIPTION
Resolve #1329:
- Remove scope skipping on create sort document
